### PR TITLE
When css class ".lg-actions .lg-prev:" is "after", arrow disapear. "b…

### DIFF
--- a/dist/css/lightgallery.css
+++ b/dist/css/lightgallery.css
@@ -52,7 +52,7 @@
 .lg-actions .lg-prev {
   left: 20px;
 }
-.lg-actions .lg-prev:after {
+.lg-actions .lg-prev:before {
   content: "\e094";
 }
 


### PR DESCRIPTION
css class ".lg-actions .lg-prev:" event is "before" not "after".

When "after", arrow disapear. "before" solve it.